### PR TITLE
Fix bug in resnet

### DIFF
--- a/antialiased_cnns/resnet.py
+++ b/antialiased_cnns/resnet.py
@@ -126,7 +126,7 @@ class Bottleneck(nn.Module):
         # Both self.conv2 and self.downsample layers downsample the input when stride != 1
         self.conv1 = conv1x1(inplanes, planes)
         self.bn1 = norm_layer(planes)
-        self.conv2 = conv3x3(planes, planes, groups) # stride moved
+        self.conv2 = conv3x3(planes, planes, groups=groups)  # stride moved
         self.bn2 = norm_layer(planes)
         if(stride==1):
             self.conv3 = conv1x1(planes, planes * self.expansion)


### PR DESCRIPTION
Fixes a subtle bug in ResNet's `Bottleneck` block

## Description

The stride in a `Bottleneck` block was moved to `conv3` from `conv2`. As a consequence `groups` is specified as a 3rd argument to the `conv3x3` function (see: https://github.com/adobe/antialiased-cnns/blob/master/antialiased_cnns/resnet.py#L129 ), however the 3rd argument of the `conv3x3` function is `stride` not `groups` (see https://github.com/adobe/antialiased-cnns/blob/master/antialiased_cnns/resnet.py#L69). This potentially introduces a bug since the `groups` would set `stride` instead)

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
